### PR TITLE
Fix the response if there is no internet available

### DIFF
--- a/lib/pages/homepage.dart
+++ b/lib/pages/homepage.dart
@@ -52,29 +52,34 @@ class _HomepageState extends State<Homepage> {
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
-        // final modelReply = data["candidates"][0]["content"]["parts"][0]["text"];
+
         String sanitizeResponse(String text) {
-          // Remove markdown bold/italic markers (*, **, _)
           return text
-              .replaceAll(RegExp(r'\*\*'), '') // remove bold markers
-              .replaceAll(RegExp(r'\*'), '') // remove italic markers
-              .replaceAll(RegExp(r'_'), ''); // remove underscores
+              .replaceAll(RegExp(r'\*\*'), '')
+              .replaceAll(RegExp(r'\*'), '')
+              .replaceAll(RegExp(r'_'), '');
         }
 
         final rawReply = data["candidates"][0]["content"]["parts"][0]["text"];
         final modelReply = sanitizeResponse(rawReply);
 
-        //instead of direct setState, use typing effect
         _showTypingEffect(modelReply);
       } else {
         setState(() {
-          _messages.add({"role": "model", "text": "Error: ${response.body}"});
+          _messages.add({
+            "role": "model",
+            "text": "Something went wrong. Please try again later.",
+          });
           _isLoading = false;
         });
       }
     } catch (e) {
       setState(() {
-        _messages.add({"role": "model", "text": "Failed to connect: $e"});
+        _messages.add({
+          "role": "model",
+          "text":
+              "No internet connection. Please check your network and try again.",
+        });
         _isLoading = false;
       });
     }


### PR DESCRIPTION
Fix the display response if there is no internet available, it should display Some friendly message telling that there is no internet available instead of displaying the exact error with the API URL and API key which is strictly against the privacy of the secrecy of the API itself.